### PR TITLE
feat: filter alloy config sections by ansible inventory name

### DIFF
--- a/ansible/roles/grafana-alloy/templates/grafana-config.alloy
+++ b/ansible/roles/grafana-alloy/templates/grafana-config.alloy
@@ -31,13 +31,23 @@ prometheus.scrape "default" {
   forward_to = [prometheus.relabel.replace_instance_with_hostname.receiver]
 }
 
-prometheus.scrape "ceramic" {
+{% if 'js-ceramic' in inventory_hostname %}
+prometheus.scrape "js_ceramic" {
   targets = [
-    {"__address__" = "127.0.0.1:9464"},
-    {"__address__" = "127.0.0.1:9465"},
+    {"job" = "js-ceramic", "__address__" = "127.0.0.1:9464"},
   ]
   forward_to = [prometheus.relabel.replace_instance_with_hostname.receiver]
 }
+{% endif %}
+
+{% if 'rust-ceramic' in inventory_hostname %}
+prometheus.scrape "rust_ceramic" {
+  targets = [
+      {"job" = "rust-ceramic", "__address__" = "127.0.0.1:9465"},
+  ]
+  forward_to = [prometheus.relabel.replace_instance_with_hostname.receiver]
+}
+{% endif %}
 
 prometheus.remote_write "grafana_cloud_prometheus" {
 	// https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.remote_write/

--- a/ansible/roles/grafana-alloy/templates/grafana-config.alloy
+++ b/ansible/roles/grafana-alloy/templates/grafana-config.alloy
@@ -49,6 +49,15 @@ prometheus.scrape "rust_ceramic" {
 }
 {% endif %}
 
+{% if 'go-ipfs' in inventory_hostname %}
+prometheus.scrape "go_ipfs" {
+  targets = [
+      {"job" = "go-ipfs", "__address__" = "127.0.0.1:5001", "metrics_path" = "/debug/metrics/prometheus"},
+  ]
+  forward_to = [prometheus.relabel.replace_instance_with_hostname.receiver]
+}
+{% endif %}
+
 prometheus.remote_write "grafana_cloud_prometheus" {
 	// https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.remote_write/
 	endpoint {


### PR DESCRIPTION
Updated grafana-alloy to filter what it's monitoring by ansible hostname.

This a pretty strict restriction and could be done with a host_var or something, but good enough for now.

Additional conditional checks can easily be added.